### PR TITLE
Add and validate flags and input parameters

### DIFF
--- a/MkRules
+++ b/MkRules
@@ -242,7 +242,7 @@ endif
 
 # Kernel choice
 ifeq ($(KERNEL), shamir)
-  KERNEL_FLAGS = -DSHAMIR_KERNEL
+  KERNEL_FLAGS = -DMEASURE_SHAMIR -DPRODUCTION_SHAMIR
 else ifeq ($(KERNEL), wilson)
   ifneq ($(NP_THIRD), 1)
     $(error Wilson kernel does not currently support NP_THIRD > 1)

--- a/MkRules
+++ b/MkRules
@@ -242,7 +242,7 @@ endif
 
 # Kernel choice
 ifeq ($(KERNEL), shamir)
-  KERNEL_FLAGS = -DMEASURE_SHAMIR -DPRODUCTION_SHAMIR
+  KERNEL_FLAGS = -DMEASURE_SHAMIR -DGENERATE_WITH_SHAMIR
 else ifeq ($(KERNEL), wilson)
   ifneq ($(NP_THIRD), 1)
     $(error Wilson kernel does not currently support NP_THIRD > 1)

--- a/dirac.F90
+++ b/dirac.F90
@@ -8,16 +8,6 @@ module dirac
 
 contains
 
-  pure subroutine verify_kernel_choice()
-#if defined(SHAMIR_KERNEL) && defined(WILSON_KERNEL)
-    Error: Must specify only one of SHAMIR_KERNEL or WILSON_KERNEL
-#endif
-
-#if !defined(SHAMIR_KERNEL) && !defined(WILSON_KERNEL)
-    Error: Must specify one of SHAMIR_KERNEL or WILSON_KERNEL
-#endif
-  end subroutine
-
   pure subroutine dslash(Phi, R, u, am, imass)
     implicit none
     complex(dp), intent(in) :: u(0:ksizex_l + 1, 0:ksizey_l + 1, 0:ksizet_l + 1, 3)

--- a/dwf3d_lib.F90
+++ b/dwf3d_lib.F90
@@ -111,7 +111,7 @@ contains
 #endif
       call exit(1)
     else if (imass .eq. 5)
-      print *, 'WARNING: imass of 5 may not be supported '
+      print *, 'WARNING: imass of 5 may not be supported.'
     end if
 
 ! set a new seed by hand...

--- a/dwf3d_lib.F90
+++ b/dwf3d_lib.F90
@@ -104,7 +104,7 @@ contains
     close (25)
 
     ! verify imass value
-    if ((imass .ne. 1) .ne. (imass .ne. 3) .and. (imass .ne. 5)) then
+    if ((imass .ne. 1) .and. (imass .ne. 3) .and. (imass .ne. 5)) then
       print *, 'ERROR: imass must be one of 1, 3 or 5'
 #ifdef MPI
       call MPI_Abort(MPI_COMM_WORLD, 1, ierr)

--- a/dwf3d_lib.F90
+++ b/dwf3d_lib.F90
@@ -103,6 +103,17 @@ contains
     read (25, *) dt, beta, am3, am, imass, iterl, iter2_read, walltimesec
     close (25)
 
+    ! verify imass value
+    if ((imass .ne. 1) .ne. (imass .ne. 3) .and. (imass .ne. 5)) then
+      print *, 'ERROR: imass must be one of 1, 3 or 5'
+#ifdef MPI
+      call MPI_Abort(MPI_COMM_WORLD, 1, ierr)
+#endif
+      call exit(1)
+    else if (imass .eq. 5)
+      print *, 'WARNING: imass of 5 may not be supported '
+    end if
+
 ! set a new seed by hand...
 
     block

--- a/params.F90
+++ b/params.F90
@@ -82,11 +82,11 @@ contains
 #endif
     
     ! Production flag
-#if defined(PRODUCTION_SHAMIR) && defined(PRODUCTION_WILSON)
-    Error: Must specify only one of PRODUCTION_SHAMIR or PRODUCTION_WILSON
+#if defined(GENERATE_WITH_SHAMIR) && defined(GENERATE_WITH_WILSON)
+    Error: Must specify only one of GENERATE_WITH_SHAMIR or GENERATE_WITH_WILSON
 #endif
-#if !defined(PRODUCTION_SHAMIR) && !defined(PRODUCTION_WILSON)
-    Error: Must specify one of PRODUCTION_SHAMIR or PRODUCTION_WILSON
+#if !defined(GENERATE_WITH_SHAMIR) && !defined(GENERATE_WITH_WILSON)
+    Error: Must specify one of GENERATE_WITH_SHAMIR or GENERATE_WITH_WILSON
 #endif
 
     

--- a/params.F90
+++ b/params.F90
@@ -70,4 +70,25 @@ module params
   real :: beta
   real :: am3
   integer :: ibound
+
+contains
+  pure subroutine verify_kernel_choice()
+    ! Measurement flag
+#if defined(MEASURE_SHAMIR) && defined(MEASURE_WILSON)
+    Error: Must specify only one of MEASURE_SHAMIR or MEASURE_WILSON
+#endif
+#if !defined(MEASURE_SHAMIR) && !defined(MEASURE_WILSON)
+    Error: Must specify one of MEASURE_SHAMIR or MEASURE_WILSON
+#endif
+    
+    ! Production flag
+#if defined(PRODUCTION_SHAMIR) && defined(PRODUCTION_WILSON)
+    Error: Must specify only one of PRODUCTION_SHAMIR or PRODUCTION_WILSON
+#endif
+#if !defined(PRODUCTION_SHAMIR) && !defined(PRODUCTION_WILSON)
+    Error: Must specify one of PRODUCTION_SHAMIR or PRODUCTION_WILSON
+#endif
+
+    
+  end subroutine
 end module params

--- a/qmrherm_module.F90
+++ b/qmrherm_module.F90
@@ -41,7 +41,7 @@ contains
     logical, intent(in), optional :: use_sp
     integer, intent(out) :: itercg
     integer, intent(out), optional :: cg_returns(ndiagq)
-    logical :: use_sp_flags_included = use_sp
+    logical :: use_sp_flags_included = .false.
     integer :: cg_returns_tmp(ndiagq)
     real(dp) :: coeff
     integer :: idiag
@@ -51,10 +51,13 @@ contains
 #endif
 
     ! Set use_sp_flags_included (sp is not implemented for the wilson version)
-#if defined(PRODUCTION_WILSON)
-    print *, 'WARNING: sp is not supported in qmrherm when using the PRODUCTION_WILSON flag. Switching to dp.'
-    use_sp_flags_included = .false.
+    if (present(use_sp)) then
+#if defined(GENERATE_WITH_SHAMIR)
+      use_sp_flags_included = use_sp
+#else 
+      print *, 'WARNING: Single precision is not supported in qmrherm when using the GENERATE_WITH_WILSON flag. Forcing double precision.'
 #endif
+    end if
 
 
     if (ndiagq .gt. ndiag) then

--- a/qmrherm_module.F90
+++ b/qmrherm_module.F90
@@ -41,6 +41,7 @@ contains
     logical, intent(in), optional :: use_sp
     integer, intent(out) :: itercg
     integer, intent(out), optional :: cg_returns(ndiagq)
+    logical :: use_sp_flags_included = use_sp
     integer :: cg_returns_tmp(ndiagq)
     real(dp) :: coeff
     integer :: idiag
@@ -48,6 +49,13 @@ contains
     integer, dimension(16) :: reqs_x2, reqs_Phi0, reqs_R, reqs_x
     integer :: ierr
 #endif
+
+    ! Set use_sp_flags_included (sp is not implemented for the wilson version)
+#if defined(PRODUCTION_WILSON)
+    print *, 'WARNING: sp is not supported in qmrherm when using the PRODUCTION_WILSON flag. Switching to dp.'
+    use_sp_flags_included = .false.
+#endif
+
 
     if (ndiagq .gt. ndiag) then
       print *, 'The qmrherm_module module currently requires ndiagq be greater than ndiagg.'
@@ -67,7 +75,7 @@ contains
     endif
 
     x = anum(0)*Phi
-    if (present(use_sp) .and. use_sp) then
+    if (present(use_sp) .and. use_sp_flags_included) then
       call multishift_solver_sp(u, am, imass, ndiagq, aden, anum(1:ndiagq), x1, Phi, res, max_qmr_iters, itercg, cg_returns_tmp)
     else
       call multishift_solver(u, am, imass, ndiagq, aden, anum(1:ndiagq), x1, Phi, res, max_qmr_iters, itercg, cg_returns_tmp)
@@ -170,7 +178,7 @@ contains
     endif ! if(iflag.lt.2)then , else
 
     if (ip_global .eq. 0 .and. printall) then
-      if (present(use_sp) .and. use_sp) then
+      if (present(use_sp) .and. use_sp_flags_included) then
         print *, "[SP] Qmrherm iterations,res:", itercg, res
       else
         print *, "[DP] Qmrherm iterations,res:", itercg, res


### PR DESCRIPTION
Review checklist:
 - [x] Add new MEASURE_(SHAMIR/WILSON) flag for measure only.
 - [x] Rename existing flag for switching dirac to also reflect that it switches kernel in derivs (new name PRODUCTION_(SHAMIR/WILSON).
 - [x] Check in dwfs_lib, when midout is read, that imass is one of {1, 3, 5} (fail if not) and warn when imass==5.
 - [x] Force switch off SP in qmrherm when using PRODUCTION_WILSON flag & warn user.